### PR TITLE
A JS Script injection to make sure the exam redirects work correctly

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           source: ./
           destination: ./_site
+      - name: Insert JS snippet
+        run: |
+          find ./_site -name '*.html' -exec sed -i 's|</body>|<script>document.addEventListener("DOMContentLoaded", function() {const links = document.querySelectorAll("a[href^=\\"./exams/\\"]");links.forEach(link => {const code = link.getAttribute("href").slice(8);link.href = `https://github.com/skipgu/past-exams/tree/main/exams/${code}`;});});</script>\n</body>|g' {} +
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
 


### PR DESCRIPTION
This is an attempt to resolve #23.

This modifies all `.html` files so that a script replaces all `./exams/<code>` links with the adress of the GitHub repo.

Resolves #23.