### PR TITLE
Resolve absolute links to exams

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           source: ./
           destination: ./_site
-      - name: Modify Permissions
-        run: chmod -R u+rwX,go+rX,go-w ./_site
-      - name: Insert JS snippet
-        run: |
-          find ./_site -name '*.html' -exec sed -i 's|</body>|<script>document.addEventListener("DOMContentLoaded", function() {const links = document.querySelectorAll("a[href^=\\"./exams/\\"]");links.forEach(link => {const code = link.getAttribute("href").slice(8);link.href = `https://github.com/skipgu/past-exams/tree/main/exams/${code}`;});});</script>\n</body>|g' {} +
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
 

--- a/README.md
+++ b/README.md
@@ -43,44 +43,57 @@ Click to expand the list of courses for each programme.
 
 ### Term 1
 
-- [DIT043 - Object-Oriented Programming](./exams/DIT043) 5 exams.
-- [DIT023 - Mathematical Foundations for Software Engineering](./exams/DIT023) 9 exams.
-- [DIT046 - Requirements and User Experience](./exams/DIT046) 5 exams.
+- [DIT043 - Object-Oriented Programming](https://github.com/skipgu/past-exams/tree/main/exams/DIT043) 5 exams.
+
+- [DIT023 - Mathematical Foundations for Software Engineering](https://github.com/skipgu/past-exams/tree/main/exams/DIT023) 9 exams.
+
+- [DIT046 - Requirements and User Experience](https://github.com/skipgu/past-exams/tree/main/exams/DIT046) 5 exams.
+
 
 ***
 
 ### Term 2
 
-- [DIT033 - Data Management](./exams/DIT033) 9 exams.
-- [DIT182 - Data Structures and Algorithms](./exams/DIT182) 24 exams.
-- [DIT185 - Software Analysis and Design](./exams/DIT185) 9 exams.
+- [DIT033 - Data Management](https://github.com/skipgu/past-exams/tree/main/exams/DIT033) 9 exams.
+
+- [DIT182 - Data Structures and Algorithms](https://github.com/skipgu/past-exams/tree/main/exams/DIT182) 24 exams.
+
+- [DIT185 - Software Analysis and Design](https://github.com/skipgu/past-exams/tree/main/exams/DIT185) 9 exams.
+
 
 ***
 
 ### Term 3
 
-- [DIT345 - Fundamentals of Software Architecture](./exams/DIT345) 5 exams.
-- [DIT342 - Web Development](./exams/DIT342) 10 exams.
-- [DIT348 - Software Development Methodologies](./exams/DIT348) 10 exams.
+- [DIT345 - Fundamentals of Software Architecture](https://github.com/skipgu/past-exams/tree/main/exams/DIT345) 5 exams.
+
+- [DIT342 - Web Development](https://github.com/skipgu/past-exams/tree/main/exams/DIT342) 10 exams.
+
+- [DIT348 - Software Development Methodologies](https://github.com/skipgu/past-exams/tree/main/exams/DIT348) 10 exams.
+
 
 ***
 
 ### Term 4
 
-- [DIT633 - Development of Embedded and Real-Time Systems](./exams/DIT633) 9 exams.
-- [DIT636 - Software Quality and Testing](./exams/DIT636) 6 exams.
+- [DIT633 - Development of Embedded and Real-Time Systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT633) 9 exams.
+
+- [DIT636 - Software Quality and Testing](https://github.com/skipgu/past-exams/tree/main/exams/DIT636) 6 exams.
+
 
 ***
 
 ### Term 5
 
-- [DIT822 - Software engineering for AI systems](./exams/DIT822) 5 exams.
+- [DIT822 - Software engineering for AI systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT822) 5 exams.
+
 
 ***
 
 ### Term 6
 
-- [DIT822 - Software engineering for AI systems](./exams/DIT822) 5 exams.
+- [DIT822 - Software engineering for AI systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT822) 5 exams.
+
 
 ***
 
@@ -91,7 +104,8 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [DIT431 - High Performance Parallel Programming](./exams/DIT431) 1 exams.
+- [DIT431 - High Performance Parallel Programming](https://github.com/skipgu/past-exams/tree/main/exams/DIT431) 1 exams.
+
 
 ***
 
@@ -102,9 +116,12 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [TIN093 - Algorithms](./exams/TIN093) 2 exams.
-- [DAT105 - Computer architecture](./exams/DAT105) 2 exams.
-- [DAT060 - Logic in computer science](./exams/DAT060) 2 exams.
+- [TIN093 - Algorithms](https://github.com/skipgu/past-exams/tree/main/exams/TIN093) 2 exams.
+
+- [DAT105 - Computer architecture](https://github.com/skipgu/past-exams/tree/main/exams/DAT105) 2 exams.
+
+- [DAT060 - Logic in computer science](https://github.com/skipgu/past-exams/tree/main/exams/DAT060) 2 exams.
+
 
 ***
 
@@ -115,11 +132,16 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) 2 exams.
-- [EDA387 - Computer networks](./exams/EDA387) 2 exams.
-- [DAT400 - High-performance parallel programming](./exams/DAT400) 1 exams.
-- [DAT246 - Empirical software engineering](./exams/DAT246) 2 exams.
-- [DAT105 - Computer architecture](./exams/DAT105) 2 exams.
+- [TDA384 - Principles of Concurrent Programming](https://github.com/skipgu/past-exams/tree/main/exams/TDA384) 2 exams.
+
+- [EDA387 - Computer networks](https://github.com/skipgu/past-exams/tree/main/exams/EDA387) 2 exams.
+
+- [DAT400 - High-performance parallel programming](https://github.com/skipgu/past-exams/tree/main/exams/DAT400) 1 exams.
+
+- [DAT246 - Empirical software engineering](https://github.com/skipgu/past-exams/tree/main/exams/DAT246) 2 exams.
+
+- [DAT105 - Computer architecture](https://github.com/skipgu/past-exams/tree/main/exams/DAT105) 2 exams.
+
 
 ***
 
@@ -130,16 +152,26 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [DIT342 - Web Development](./exams/DIT342) 10 exams.
-- [DIT348 - Software Development Methodologies](./exams/DIT348) 10 exams.
-- [DIT185 - Software Analysis and Design](./exams/DIT185) 9 exams.
-- [DIT401 - Operating Systems](./exams/DIT401) 1 exams.
-- [DIT093 - Algorithms](./exams/DIT093) 1 exams.
-- [DIT440 - Introduction to Functional Programming](./exams/DIT440) 2 exams.
-- [DIT792 - Grundläggande datorteknik](./exams/DIT792) 1 exams.
-- [DIT962 - Datastrukturer | Data Structures](./exams/DIT962) 2 exams.
-- [DIT980 - Diskret matematik för Datavetare](./exams/DIT980) 1 exams.
-- [DIT984 - Diskret matematik för Datavetare](./exams/DIT984) 1 exams.
+- [DIT342 - Web Development](https://github.com/skipgu/past-exams/tree/main/exams/DIT342) 10 exams.
+
+- [DIT348 - Software Development Methodologies](https://github.com/skipgu/past-exams/tree/main/exams/DIT348) 10 exams.
+
+- [DIT185 - Software Analysis and Design](https://github.com/skipgu/past-exams/tree/main/exams/DIT185) 9 exams.
+
+- [DIT401 - Operating Systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT401) 1 exams.
+
+- [DIT093 - Algorithms](https://github.com/skipgu/past-exams/tree/main/exams/DIT093) 1 exams.
+
+- [DIT440 - Introduction to Functional Programming](https://github.com/skipgu/past-exams/tree/main/exams/DIT440) 2 exams.
+
+- [DIT792 - Grundläggande datorteknik](https://github.com/skipgu/past-exams/tree/main/exams/DIT792) 1 exams.
+
+- [DIT962 - Datastrukturer | Data Structures](https://github.com/skipgu/past-exams/tree/main/exams/DIT962) 2 exams.
+
+- [DIT980 - Diskret matematik för Datavetare](https://github.com/skipgu/past-exams/tree/main/exams/DIT980) 1 exams.
+
+- [DIT984 - Diskret matematik för Datavetare](https://github.com/skipgu/past-exams/tree/main/exams/DIT984) 1 exams.
+
 
 ***
 
@@ -150,14 +182,22 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [DIT822 - Software engineering for AI systems](./exams/DIT822) 5 exams.
-- [DIT046 - Requirements and User Experience](./exams/DIT046) 5 exams.
-- [DIT401 - Operating Systems](./exams/DIT401) 1 exams.
-- [DIT431 - High Performance Parallel Programming](./exams/DIT431) 1 exams.
-- [DIT182 - Data Structures and Algorithms](./exams/DIT182) 24 exams.
-- [DIT033 - Data Management](./exams/DIT033) 9 exams.
-- [DIT093 - Algorithms](./exams/DIT093) 1 exams.
-- [DIT852 - Introduction to Data Science](./exams/DIT852) 2 exams.
+- [DIT822 - Software engineering for AI systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT822) 5 exams.
+
+- [DIT046 - Requirements and User Experience](https://github.com/skipgu/past-exams/tree/main/exams/DIT046) 5 exams.
+
+- [DIT401 - Operating Systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT401) 1 exams.
+
+- [DIT431 - High Performance Parallel Programming](https://github.com/skipgu/past-exams/tree/main/exams/DIT431) 1 exams.
+
+- [DIT182 - Data Structures and Algorithms](https://github.com/skipgu/past-exams/tree/main/exams/DIT182) 24 exams.
+
+- [DIT033 - Data Management](https://github.com/skipgu/past-exams/tree/main/exams/DIT033) 9 exams.
+
+- [DIT093 - Algorithms](https://github.com/skipgu/past-exams/tree/main/exams/DIT093) 1 exams.
+
+- [DIT852 - Introduction to Data Science](https://github.com/skipgu/past-exams/tree/main/exams/DIT852) 2 exams.
+
 
 ***
 
@@ -168,10 +208,14 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [DIT401 - Operating Systems](./exams/DIT401) 1 exams.
-- [DIT431 - High Performance Parallel Programming](./exams/DIT431) 1 exams.
-- [DIT093 - Algorithms](./exams/DIT093) 1 exams.
-- [DIT670 - Computer Networks](./exams/DIT670) 1 exams.
+- [DIT401 - Operating Systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT401) 1 exams.
+
+- [DIT431 - High Performance Parallel Programming](https://github.com/skipgu/past-exams/tree/main/exams/DIT431) 1 exams.
+
+- [DIT093 - Algorithms](https://github.com/skipgu/past-exams/tree/main/exams/DIT093) 1 exams.
+
+- [DIT670 - Computer Networks](https://github.com/skipgu/past-exams/tree/main/exams/DIT670) 1 exams.
+
 
 ***
 
@@ -182,15 +226,19 @@ Click to expand the list of courses for each programme.
 
 ### Year 2 - AUTUMN TERM - Study period 1 (compulsory)
 
-- [DAT050 - Objektorienterad programmering | Object oriented programming](./exams/DAT050) 2 exams.
+- [DAT050 - Objektorienterad programmering | Object oriented programming](https://github.com/skipgu/past-exams/tree/main/exams/DAT050) 2 exams.
+
 
 ***
 
 ### 
 
-- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) 2 exams.
-- [EDA387 - Computer networks](./exams/EDA387) 2 exams.
-- [EDA093 - Operating systems](./exams/EDA093) 1 exams.
+- [TDA384 - Principles of Concurrent Programming](https://github.com/skipgu/past-exams/tree/main/exams/TDA384) 2 exams.
+
+- [EDA387 - Computer networks](https://github.com/skipgu/past-exams/tree/main/exams/EDA387) 2 exams.
+
+- [EDA093 - Operating systems](https://github.com/skipgu/past-exams/tree/main/exams/EDA093) 1 exams.
+
 
 ***
 
@@ -201,7 +249,8 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [EDA093 - Operating systems](./exams/EDA093) 1 exams.
+- [EDA093 - Operating systems](https://github.com/skipgu/past-exams/tree/main/exams/EDA093) 1 exams.
+
 
 ***
 
@@ -212,9 +261,12 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [TDA555 - Introduction to functional programming](./exams/TDA555) 2 exams.
-- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) 2 exams.
-- [EDA452 - Grundläggande datorteknik | Introduction to computer engineering](./exams/EDA452) 1 exams.
+- [TDA555 - Introduction to functional programming](https://github.com/skipgu/past-exams/tree/main/exams/TDA555) 2 exams.
+
+- [TDA384 - Principles of Concurrent Programming](https://github.com/skipgu/past-exams/tree/main/exams/TDA384) 2 exams.
+
+- [EDA452 - Grundläggande datorteknik | Introduction to computer engineering](https://github.com/skipgu/past-exams/tree/main/exams/EDA452) 1 exams.
+
 
 ***
 
@@ -225,7 +277,8 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [DAT555 - Programmeringsteknik i Python | Programming in Python](./exams/DAT555) 2 exams.
+- [DAT555 - Programmeringsteknik i Python | Programming in Python](https://github.com/skipgu/past-exams/tree/main/exams/DAT555) 2 exams.
+
 
 ***
 
@@ -236,8 +289,10 @@ Click to expand the list of courses for each programme.
 
 ### 
 
-- [TDA548 - Grundläggande programvaruutveckling | Introductory software development](./exams/TDA548) 2 exams.
-- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) 2 exams.
+- [TDA548 - Grundläggande programvaruutveckling | Introductory software development](https://github.com/skipgu/past-exams/tree/main/exams/TDA548) 2 exams.
+
+- [TDA384 - Principles of Concurrent Programming](https://github.com/skipgu/past-exams/tree/main/exams/TDA384) 2 exams.
+
 
 ***
 

--- a/descriptionCreator/modules/processData.js
+++ b/descriptionCreator/modules/processData.js
@@ -184,7 +184,7 @@ export function processData(settings) {
           courseCredit: credits,
           courseLevel: level,
           courseExamCount: exams,
-          courseDirectory: `./exams/${courseCode}`
+          courseDirectory: `exams/${courseCode}`
         }))
       }))
     }))

--- a/descriptionCreator/static/course.md
+++ b/descriptionCreator/static/course.md
@@ -1,1 +1,1 @@
-- [{{courseCode}} - {{courseName}}]({{courseDirectory}}){{examCount.md}}
+- [{{courseCode}} - {{courseName}}](https://github.com/skipgu/past-exams/tree/main/{{courseDirectory}}){{examCount.md}}

--- a/exams.json
+++ b/exams.json
@@ -14,7 +14,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT043"
+              "courseDirectory": "exams/DIT043"
             },
             {
               "courseCode": "DIT023",
@@ -22,7 +22,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 9,
-              "courseDirectory": "./exams/DIT023"
+              "courseDirectory": "exams/DIT023"
             },
             {
               "courseCode": "DIT046",
@@ -30,7 +30,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT046"
+              "courseDirectory": "exams/DIT046"
             }
           ]
         },
@@ -43,7 +43,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 9,
-              "courseDirectory": "./exams/DIT033"
+              "courseDirectory": "exams/DIT033"
             },
             {
               "courseCode": "DIT182",
@@ -51,7 +51,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 24,
-              "courseDirectory": "./exams/DIT182"
+              "courseDirectory": "exams/DIT182"
             },
             {
               "courseCode": "DIT185",
@@ -59,7 +59,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 9,
-              "courseDirectory": "./exams/DIT185"
+              "courseDirectory": "exams/DIT185"
             }
           ]
         },
@@ -72,7 +72,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT345"
+              "courseDirectory": "exams/DIT345"
             },
             {
               "courseCode": "DIT342",
@@ -80,7 +80,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 10,
-              "courseDirectory": "./exams/DIT342"
+              "courseDirectory": "exams/DIT342"
             },
             {
               "courseCode": "DIT348",
@@ -88,7 +88,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 10,
-              "courseDirectory": "./exams/DIT348"
+              "courseDirectory": "exams/DIT348"
             }
           ]
         },
@@ -101,7 +101,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 9,
-              "courseDirectory": "./exams/DIT633"
+              "courseDirectory": "exams/DIT633"
             },
             {
               "courseCode": "DIT636",
@@ -109,7 +109,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 6,
-              "courseDirectory": "./exams/DIT636"
+              "courseDirectory": "exams/DIT636"
             }
           ]
         },
@@ -122,7 +122,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT822"
+              "courseDirectory": "exams/DIT822"
             }
           ]
         },
@@ -135,7 +135,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT822"
+              "courseDirectory": "exams/DIT822"
             }
           ]
         }
@@ -155,7 +155,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT431"
+              "courseDirectory": "exams/DIT431"
             }
           ]
         }
@@ -175,7 +175,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TIN093"
+              "courseDirectory": "exams/TIN093"
             },
             {
               "courseCode": "DAT105",
@@ -183,7 +183,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DAT105"
+              "courseDirectory": "exams/DAT105"
             },
             {
               "courseCode": "DAT060",
@@ -191,7 +191,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DAT060"
+              "courseDirectory": "exams/DAT060"
             }
           ]
         }
@@ -211,7 +211,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TDA384"
+              "courseDirectory": "exams/TDA384"
             },
             {
               "courseCode": "EDA387",
@@ -219,7 +219,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/EDA387"
+              "courseDirectory": "exams/EDA387"
             },
             {
               "courseCode": "DAT400",
@@ -227,7 +227,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DAT400"
+              "courseDirectory": "exams/DAT400"
             },
             {
               "courseCode": "DAT246",
@@ -235,7 +235,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DAT246"
+              "courseDirectory": "exams/DAT246"
             },
             {
               "courseCode": "DAT105",
@@ -243,7 +243,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DAT105"
+              "courseDirectory": "exams/DAT105"
             }
           ]
         }
@@ -263,7 +263,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 10,
-              "courseDirectory": "./exams/DIT342"
+              "courseDirectory": "exams/DIT342"
             },
             {
               "courseCode": "DIT348",
@@ -271,7 +271,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 10,
-              "courseDirectory": "./exams/DIT348"
+              "courseDirectory": "exams/DIT348"
             },
             {
               "courseCode": "DIT185",
@@ -279,7 +279,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 9,
-              "courseDirectory": "./exams/DIT185"
+              "courseDirectory": "exams/DIT185"
             },
             {
               "courseCode": "DIT401",
@@ -287,7 +287,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT401"
+              "courseDirectory": "exams/DIT401"
             },
             {
               "courseCode": "DIT093",
@@ -295,7 +295,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT093"
+              "courseDirectory": "exams/DIT093"
             },
             {
               "courseCode": "DIT440",
@@ -303,7 +303,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DIT440"
+              "courseDirectory": "exams/DIT440"
             },
             {
               "courseCode": "DIT792",
@@ -311,7 +311,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT792"
+              "courseDirectory": "exams/DIT792"
             },
             {
               "courseCode": "DIT962",
@@ -319,7 +319,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DIT962"
+              "courseDirectory": "exams/DIT962"
             },
             {
               "courseCode": "DIT980",
@@ -327,7 +327,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT980"
+              "courseDirectory": "exams/DIT980"
             },
             {
               "courseCode": "DIT984",
@@ -335,7 +335,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT984"
+              "courseDirectory": "exams/DIT984"
             }
           ]
         }
@@ -355,7 +355,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT822"
+              "courseDirectory": "exams/DIT822"
             },
             {
               "courseCode": "DIT046",
@@ -363,7 +363,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 5,
-              "courseDirectory": "./exams/DIT046"
+              "courseDirectory": "exams/DIT046"
             },
             {
               "courseCode": "DIT401",
@@ -371,7 +371,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT401"
+              "courseDirectory": "exams/DIT401"
             },
             {
               "courseCode": "DIT431",
@@ -379,7 +379,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT431"
+              "courseDirectory": "exams/DIT431"
             },
             {
               "courseCode": "DIT182",
@@ -387,7 +387,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 24,
-              "courseDirectory": "./exams/DIT182"
+              "courseDirectory": "exams/DIT182"
             },
             {
               "courseCode": "DIT033",
@@ -395,7 +395,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 9,
-              "courseDirectory": "./exams/DIT033"
+              "courseDirectory": "exams/DIT033"
             },
             {
               "courseCode": "DIT093",
@@ -403,7 +403,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT093"
+              "courseDirectory": "exams/DIT093"
             },
             {
               "courseCode": "DIT852",
@@ -411,7 +411,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DIT852"
+              "courseDirectory": "exams/DIT852"
             }
           ]
         }
@@ -431,7 +431,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT401"
+              "courseDirectory": "exams/DIT401"
             },
             {
               "courseCode": "DIT431",
@@ -439,7 +439,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT431"
+              "courseDirectory": "exams/DIT431"
             },
             {
               "courseCode": "DIT093",
@@ -447,7 +447,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT093"
+              "courseDirectory": "exams/DIT093"
             },
             {
               "courseCode": "DIT670",
@@ -455,7 +455,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/DIT670"
+              "courseDirectory": "exams/DIT670"
             }
           ]
         }
@@ -475,7 +475,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DAT050"
+              "courseDirectory": "exams/DAT050"
             }
           ]
         },
@@ -488,7 +488,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TDA384"
+              "courseDirectory": "exams/TDA384"
             },
             {
               "courseCode": "EDA387",
@@ -496,7 +496,7 @@
               "courseCredit": 7.5,
               "courseLevel": "master",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/EDA387"
+              "courseDirectory": "exams/EDA387"
             },
             {
               "courseCode": "EDA093",
@@ -504,7 +504,7 @@
               "courseCredit": 4.5,
               "courseLevel": "bachelor",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/EDA093"
+              "courseDirectory": "exams/EDA093"
             }
           ]
         }
@@ -524,7 +524,7 @@
               "courseCredit": 4.5,
               "courseLevel": "bachelor",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/EDA093"
+              "courseDirectory": "exams/EDA093"
             }
           ]
         }
@@ -544,7 +544,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TDA555"
+              "courseDirectory": "exams/TDA555"
             },
             {
               "courseCode": "TDA384",
@@ -552,7 +552,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TDA384"
+              "courseDirectory": "exams/TDA384"
             },
             {
               "courseCode": "EDA452",
@@ -560,7 +560,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 1,
-              "courseDirectory": "./exams/EDA452"
+              "courseDirectory": "exams/EDA452"
             }
           ]
         }
@@ -580,7 +580,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/DAT555"
+              "courseDirectory": "exams/DAT555"
             }
           ]
         }
@@ -600,7 +600,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TDA548"
+              "courseDirectory": "exams/TDA548"
             },
             {
               "courseCode": "TDA384",
@@ -608,7 +608,7 @@
               "courseCredit": 7.5,
               "courseLevel": "bachelor",
               "courseExamCount": 2,
-              "courseDirectory": "./exams/TDA384"
+              "courseDirectory": "exams/TDA384"
             }
           ]
         }


### PR DESCRIPTION
## Resolve absolute links to exams

This change **prepends** the link to individual exams of a course (see `course.md`). This should hopefully resolve the issue without any fancy script or change in the current pipeline (i.e. GitHub Action).

Ultimately, this change should make both the `README.md` file to include the links correctly, as well as the built website hosted at <https://skipgu.org/past-exams/>.

Closes #23