### PR TITLE
Main Readme Links broken (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,41 +29,40 @@ Click to expand the list of courses for each programme.
 
 ### Year 1: SP1 & SP2
 
-- [DIT008 - Discrete Mathematics](./DIT008) (3 exams)
-- [DIT009 - Fundamentals of Programming](./DIT009) (2 exams)
-- [DIT044 - Object-Oriented Programming](./DIT044) (2 exams)
-- **_OLD_** [DIT023 - Mathematical Foundations for Software Engineering](./DIT023) (9 exams)
-- **_OLD_** [DIT043 - Object-Oriented Programming](./DIT043) (6 exams)
-- **_OLD_** [DIT046 - Requirements and User Experience](./DIT046) (5 exams)
+- [DIT008 - Discrete Mathematics](./exams/DIT008) (4 exams)
+- [DIT009 - Fundamentals of Programming](./exams/DIT009) (4 exams)
+- [DIT044 - Object-Oriented Programming](./exams/DIT044) (3 exams)
+- **_OLD_** [DIT023 - Mathematical Foundations for Software Engineering](./exams/DIT023) (9 exams)
+- **_OLD_** [DIT043 - Object-Oriented Programming](./exams/DIT043) (6 exams)
+- **_OLD_** [DIT046 - Requirements and User Experience](./exams/DIT046) (6 exams)
 
 ### Year 1: SP3 & SP4
 
-- [DIT047 - Requirements Engineering](./DIT047) (1 exams)
-- [DIT033 - Data Management](./DIT033) (9 exams)
-- **_OLD_** [DIT185 - Software Analysis and Design](./DIT185) (9 exams)
+- [DIT047 - Requirements Engineering](./exams/DIT047) (1 exams)
+- [DIT033 - Data Management](./exams/DIT033) (17 exams)
+- [DIT182 - Data Structures and Algorithms](./exams/DIT182) (20+ exams)
+- **_OLD_** [DIT185 - Software Analysis and Design](./exams/DIT185) (9 exams)
 
 ### Year 2: SP1 & SP2
 
-- [DIT345 - Fundamentals of Software Architecture](./DIT345) (9 exams)
-- **_OLD_** [DIT342 - Web Development](./DIT342) (16 exams)
+- [DIT357 - Distributed Systems](./exams/DIT357) (1 exams)
+- [DIT345 - Fundamentals of Software Architecture](./exams/DIT345) (11 exams)
+- [DIT096 - Human-Computer Interaction](./exams/DIT096) (3 exams)
+- **_OLD_** [DIT342 - Web Development](./exams/DIT342) (18 exams)
+- **_OLD_** [DIT348 - Software Development Methodologies](./exams/DIT348) (10 exams)
 
 ### Year 2: SP4 & SP4
 
-<<<<<<< HEAD
-- [DIT633 - Development of Embedded and Real-Time Systems](https://github.com/skipgu/past-exams/tree/main/exams/DIT633) (10 exams)
-- [DIT636 - Software Quality and Testing](https://github.com/skipgu/past-exams/tree/main/exams/DIT636) (9 exams)
-=======
-- [DIT633 - Development of Embedded and Real-Time Systems](./DIT633) (11 exams)
-- [DIT636 - Software Quality and Testing](./DIT636) (9 exams)
->>>>>>> 1fe1e4a (feat: update pattern rules; add docs (#48))
+- [DIT633 - Development of Embedded and Real-Time Systems](./exams/DIT633) (14 exams)
+- [DIT636 - Software Quality and Testing](./exams/DIT636) (12 exams)
 
 ### Year 3: SP1 & SP2
 
-- [DIT822 - Software engineering for AI systems](./DIT822) (7 exams)
+- [DIT822 - Software engineering for AI systems](./exams/DIT822) (10 exams)
 
 ### Year 3: SP4 & SP4
 
-- [DIT822 - Software engineering for AI systems](./DIT822) (7 exams)
+- [DIT822 - Software engineering for AI systems](./exams/DIT822) (10 exams)
 
 ***
 
@@ -74,7 +73,7 @@ Click to expand the list of courses for each programme.
 
 ### Year 2: SP1 & SP2 (compulsory)
 
-- [DAT050 - Objektorienterad programmering | Object oriented programming](./DAT050) (2 exams)
+- [DAT050 - Objektorienterad programmering | Object oriented programming](./exams/DAT050) (2 exams)
 
 ***
 
@@ -83,9 +82,9 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; MPALG - Computer science - algorithms, languages and logic, MSc</b></summary>
 
-- [DAT060 - Logic in computer science](./DAT060) (2 exams)
-- [DAT105 - Computer architecture](./DAT105) (2 exams)
-- [TIN093 - Algorithms](./TIN093) (2 exams)
+- [DAT060 - Logic in computer science](./exams/DAT060) (2 exams)
+- [DAT105 - Computer architecture](./exams/DAT105) (2 exams)
+- [TIN093 - Algorithms](./exams/TIN093) (2 exams)
 
 ***
 
@@ -94,11 +93,11 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; MPHPC - High-performance computer systems, MSc</b></summary>
 
-- [DAT105 - Computer architecture](./DAT105) (2 exams)
-- [DAT246 - Empirical software engineering](./DAT246) (2 exams)
-- [DAT400 - High-performance parallel programming](./DAT400) (1 exams)
-- [EDA387 - Computer networks](./EDA387) (2 exams)
-- [TDA384 - Principles of Concurrent Programming](./TDA384) (2 exams)
+- [DAT105 - Computer architecture](./exams/DAT105) (2 exams)
+- [DAT246 - Empirical software engineering](./exams/DAT246) (4 exams)
+- [DAT400 - High-performance parallel programming](./exams/DAT400) (1 exams)
+- [EDA387 - Computer networks](./exams/EDA387) (2 exams)
+- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) (2 exams)
 
 ***
 
@@ -107,16 +106,16 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; N1COS - Datavetenskapligt program | Computer Science, Bachelor's Programme</b></summary>
 
-- [DIT093 - Algorithms](./DIT093) (1 exams)
-- **_OLD_** [DIT185 - Software Analysis and Design](./DIT185) (9 exams)
-- **_OLD_** [DIT342 - Web Development](./DIT342) (16 exams)
-- **_OLD_** [DIT348 - Software Development Methodologies](./DIT348) (0 exams)
-- [DIT401 - Operating Systems](./DIT401) (1 exams)
-- [DIT440 - Introduction to Functional Programming](./DIT440) (2 exams)
-- [DIT792 - Grundläggande datorteknik](./DIT792) (1 exams)
-- [DIT962 - Datastrukturer | Data Structures](./DIT962) (2 exams)
-- [DIT980 - Diskret matematik för Datavetare](./DIT980) (1 exams)
-- [DIT984 - Diskret matematik för Datavetare](./DIT984) (1 exams)
+- [DIT093 - Algorithms](./exams/DIT093) (1 exams)
+- **_OLD_** [DIT185 - Software Analysis and Design](./exams/DIT185) (9 exams)
+- **_OLD_** [DIT342 - Web Development](./exams/DIT342) (18 exams)
+- **_OLD_** [DIT348 - Software Development Methodologies](./exams/DIT348) (10 exams)
+- [DIT401 - Operating Systems](./exams/DIT401) (1 exams)
+- [DIT440 - Introduction to Functional Programming](./exams/DIT440) (2 exams)
+- [DIT792 - Grundläggande datorteknik](./exams/DIT792) (1 exams)
+- [DIT962 - Datastrukturer | Data Structures](./exams/DIT962) (2 exams)
+- [DIT980 - Diskret matematik för Datavetare](./exams/DIT980) (1 exams)
+- [DIT984 - Diskret matematik för Datavetare](./exams/DIT984) (1 exams)
 
 ***
 
@@ -125,14 +124,14 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; N2ADS - Applied Data Science Master's Programme</b></summary>
 
-- [DIT033 - Data Management](./DIT033) (9 exams)
-- **_OLD_** [DIT046 - Requirements and User Experience](./DIT046) (5 exams)
-- [DIT093 - Algorithms](./DIT093) (1 exams)
-- [DIT182 - Data Structures and Algorithms](./DIT182) (0 exams)
-- [DIT401 - Operating Systems](./DIT401) (1 exams)
-- [DIT431 - High Performance Parallel Programming](./DIT431) (1 exams)
-- [DIT822 - Software engineering for AI systems](./DIT822) (7 exams)
-- [DIT852 - Introduction to Data Science](./DIT852) (2 exams)
+- [DIT033 - Data Management](./exams/DIT033) (17 exams)
+- **_OLD_** [DIT046 - Requirements and User Experience](./exams/DIT046) (5 exams)
+- [DIT093 - Algorithms](./exams/DIT093) (1 exams)
+- [DIT182 - Data Structures and Algorithms](./exams/DIT182) (27+ exams)
+- [DIT401 - Operating Systems](./exams/DIT401) (1 exams)
+- [DIT431 - High Performance Parallel Programming](./exams/DIT431) (1 exams)
+- [DIT822 - Software engineering for AI systems](./exams/DIT822) (10 exams)
+- [DIT852 - Introduction to Data Science](./exams/DIT852) (2 exams)
 
 ***
 
@@ -141,10 +140,10 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; N2COS - Computer Science Master's Programme</b></summary>
 
-- [DIT093 - Algorithms](./DIT093) (1 exams)
-- [DIT401 - Operating Systems](./DIT401) (1 exams)
-- [DIT431 - High Performance Parallel Programming](./DIT431) (1 exams)
-- [DIT670 - Computer Networks](./DIT670) (1 exams)
+- [DIT093 - Algorithms](./exams/DIT093) (1 exams)
+- [DIT401 - Operating Systems](./exams/DIT401) (1 exams)
+- [DIT431 - High Performance Parallel Programming](./exams/DIT431) (1 exams)
+- [DIT670 - Computer Networks](./exams/DIT670) (1 exams)
 
 ***
 
@@ -161,7 +160,7 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; N2SOF - Software Engineering and Management Master's Programme</b></summary>
 
-- [DIT431 - High Performance Parallel Programming](./DIT431) (1 exams)
+- [DIT431 - High Performance Parallel Programming](./exams/DIT431) (1 exams)
 
 ***
 
@@ -170,7 +169,7 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; TIELL - Elektroteknik, högskoleingenjör | Electrical Engineering</b></summary>
 
-- [EDA093 - Operating systems](./EDA093) (1 exams)
+- [EDA093 - Operating systems](./exams/EDA093) (1 exams)
 
 ***
 
@@ -179,9 +178,9 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; TKDAT - Datateknik, civilingenjör | Computer Science and Engineering</b></summary>
 
-- [EDA452 - Grundläggande datorteknik | Introduction to computer engineering](./EDA452) (1 exams)
-- [TDA384 - Principles of Concurrent Programming](./TDA384) (2 exams)
-- [TDA555 - Introduction to functional programming](./TDA555) (2 exams)
+- [EDA452 - Grundläggande datorteknik | Introduction to computer engineering](./exams/EDA452) (1 exams)
+- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) (2 exams)
+- [TDA555 - Introduction to functional programming](./exams/TDA555) (2 exams)
 
 ***
 
@@ -190,7 +189,7 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; TKIEK - Industriell ekonomi, civilingenjör | Industrial Engineering and Management</b></summary>
 
-- [DAT555 - Programmeringsteknik i Python | Programming in Python](./DAT555) (2 exams)
+- [DAT555 - Programmeringsteknik i Python | Programming in Python](./exams/DAT555) (2 exams)
 
 ***
 
@@ -199,8 +198,8 @@ Click to expand the list of courses for each programme.
 <details>
 <summary><b>&#x1F447; TKITE - Informationsteknik, civilingenjör | Software Engineering</b></summary>
 
-- [TDA384 - Principles of Concurrent Programming](./TDA384) (2 exams)
-- [TDA548 - Grundläggande programvaruutveckling | Introductory software development](./TDA548) (2 exams)
+- [TDA384 - Principles of Concurrent Programming](./exams/TDA384) (2 exams)
+- [TDA548 - Grundläggande programvaruutveckling | Introductory software development](./exams/TDA548) (2 exams)
 
 ***
 


### PR DESCRIPTION
We have been informed that the links on the main readme are not working after the last merge. This PR fixes that. These changes should be also reflected in the next version of the script #59 to not let this happen again.

Closes #61 